### PR TITLE
added missing include in network.h

### DIFF
--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -25,6 +25,7 @@
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
+#include <iostream>
 #include <stdexcept>
 #include <algorithm>
 #include <iterator>


### PR DESCRIPTION
added missing include of <iostream> to make std::cout known, fixes compiler error in line 142