### PR TITLE
Pull Request for ELU and Initialization

### DIFF
--- a/tiny_cnn/activations/activation_function.h
+++ b/tiny_cnn/activations/activation_function.h
@@ -79,9 +79,8 @@ public:
 
 class elu : public function {
 public:
-	float_t f(const float_t x) const { return (x<0 ? (exp(x)-1) : x); }
-    float_t f(const vec_t& v, size_t i) const override { return f(v[i]); }
-    float_t df(float_t y) const override { return (y > 0.0 ? 1.0 : 1+f(y)); }
+    float_t f(const vec_t& v, size_t i) const override { return (v[i]<0 ? (exp(v[i])-1) : v[i]); }
+    float_t df(float_t y) const override { return (y > 0.0 ? 1.0 : (1+y)); }
     std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
 };
 

--- a/tiny_cnn/activations/activation_function.h
+++ b/tiny_cnn/activations/activation_function.h
@@ -77,6 +77,14 @@ public:
     std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
 };
 
+class elu : public function {
+public:
+	float_t f(const float_t x) const { return (x<0 ? (exp(x)-1) : x); }
+    float_t f(const vec_t& v, size_t i) const override { return f(v[i]); }
+    float_t df(float_t y) const override { return (y > 0.0 ? 1.0 : 1+f(y)); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+};
+
 class softmax : public function {
 public:
     float_t f(const vec_t& v, size_t i) const override {

--- a/tiny_cnn/layers/fully_connected_layer.h
+++ b/tiny_cnn/layers/fully_connected_layer.h
@@ -88,7 +88,7 @@ public:
             prev_delta[c] *= prev_h.df(prev_out[c]);
         }
 
-        for_(parallelize_, 0, out_size_, [&](const blocked_range& r) {
+        for_(parallelize_, 0, size_t(out_size_), [&](const blocked_range& r) {
             // accumulate weight-step using delta
             // dW[c * out_size + i] += current_delta[i] * prev_out[c]
             for (layer_size_t c = 0; c < in_size_; c++)

--- a/tiny_cnn/layers/max_pooling_layer.h
+++ b/tiny_cnn/layers/max_pooling_layer.h
@@ -82,7 +82,7 @@ public:
         vec_t& a = a_[index];
         std::vector<int>& max_idx = out2inmax_[index];
 
-        for_(parallelize_, 0, out_size_, [&](const blocked_range& r) {
+        for_(parallelize_, 0, size_t(out_size_), [&](const blocked_range& r) {
             for (int i = r.begin(); i < r.end(); i++) {
                 const auto& in_index = out2in_[i];
                 float_t max_value = std::numeric_limits<float_t>::lowest();

--- a/tiny_cnn/layers/partial_connected_layer.h
+++ b/tiny_cnn/layers/partial_connected_layer.h
@@ -113,7 +113,7 @@ public:
         const activation::function& prev_h = prev_->activation_function();
         vec_t& prev_delta = prev_delta_[index];
 
-        for_(parallelize_, 0, in_size_, [&](const blocked_range& r) {
+        for_(parallelize_, 0, size_t(in_size_), [&](const blocked_range& r) {
             for (int i = r.begin(); i != r.end(); i++) {
                 const wo_connections& connections = in2wo_[i];
                 float_t delta = 0.0;

--- a/tiny_cnn/util/weight_init.h
+++ b/tiny_cnn/util/weight_init.h
@@ -112,5 +112,19 @@ public:
     }
 };
 
+class he : public scalable {
+public:
+    he() : scalable((float_t)2.0) {}
+    explicit he(float_t value) : scalable(value) {}
+
+    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
+        CNN_UNREFERENCED_PARAMETER(fan_out);
+
+        const float_t sigma = std::sqrt(scale_ /fan_in);
+
+        gaussian_rand(weight->begin(), weight->end(), 0.0, sigma);
+    }
+};
+
 } // namespace weight_init
 } // namespace tiny_cnn


### PR DESCRIPTION
I have found ELU activation units to be working quite good when initialized with the implemented method. The loss is multiclass cross entropy, which is optimized via Adam. I think it's useful to have it in tiny-cnn. Here is a summary:

- ELU (Exponential linear units) activation function added (http://arxiv.org/pdf/1511.07289v3.pdf).
- He et. al. weight initialization added (http://arxiv.org/pdf/1502.01852v1.pdf).
- for_ was raising a compile error on VC 2012 with TBB (due to type ambiguity). This is fixed via a cast operation.