### PR TITLE
Fixes to previous PR #81

### DIFF
--- a/tiny_cnn/activations/activation_function.h
+++ b/tiny_cnn/activations/activation_function.h
@@ -35,9 +35,13 @@ class function {
 public:
     function() = default;
     function(const function &) = default;
+#ifndef CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
     function(function &&) = default;
+#endif
     function &operator =(const function &) = default;
+#ifndef CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
     function &operator =(function &&) = default;
+#endif
     virtual ~function() = default;
 
     virtual float_t f(const vec_t& v, size_t index) const = 0;

--- a/tiny_cnn/activations/activation_function.h
+++ b/tiny_cnn/activations/activation_function.h
@@ -60,24 +60,24 @@ class identity : public function {
 public:
     using function::df;
     float_t f(const vec_t& v, size_t i) const override { return v[i]; }
-    float_t df(float_t /*y*/) const override { return 1; }  
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+    float_t df(float_t /*y*/) const override { return float_t(1); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 class sigmoid : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, size_t i) const override { return 1.0 / (1.0 + std::exp(-v[i])); }
-    float_t df(float_t y) const override { return y * (1.0 - y); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+    float_t f(const vec_t& v, size_t i) const override { return float_t(1) / (float_t(1) + std::exp(-v[i])); }
+    float_t df(float_t y) const override { return y * (float_t(1) - y); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 class relu : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, size_t i) const override { return std::max(static_cast<float_t>(0.0), v[i]); }
-    float_t df(float_t y) const override { return y > 0.0 ? 1.0 : 0.0; }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+    float_t f(const vec_t& v, size_t i) const override { return std::max(float_t(0), v[i]); }
+    float_t df(float_t y) const override { return y > float_t(0) ? float_t(1) : float_t(0); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 typedef relu rectified_linear; // for compatibility
@@ -85,17 +85,17 @@ typedef relu rectified_linear; // for compatibility
 class leaky_relu : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, size_t i) const override { return (v[i] > 0) ? v[i] : 0.01 * v[i]; }
-    float_t df(float_t y) const override { return y > 0.0 ? 1.0 : 0.01; }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+    float_t f(const vec_t& v, size_t i) const override { return (v[i] > float_t(0)) ? v[i] : float_t(0.01) * v[i]; }
+    float_t df(float_t y) const override { return y > float_t(0) ? float_t(1) : float_t(0.01); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 class elu : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, size_t i) const override { return (v[i]<0 ? (exp(v[i])-1) : v[i]); }
-    float_t df(float_t y) const override { return (y > 0.0 ? 1.0 : (1+y)); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+    float_t f(const vec_t& v, size_t i) const override { return (v[i]<float_t(0) ? (exp(v[i])- float_t(1)) : v[i]); }
+    float_t df(float_t y) const override { return (y > float_t(0) ? float_t(1) : (float_t(1)+y)); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 class softmax : public function {
@@ -103,14 +103,14 @@ public:
     float_t f(const vec_t& v, size_t i) const override {
         float_t alpha = *std::max_element(v.begin(), v.end());
         float_t numer = std::exp(v[i] - alpha);
-        float_t denom = 0.0;
+        float_t denom = float_t(0);
         for (auto x : v)
             denom += std::exp(x - alpha);
         return numer / denom;
     }
 
     float_t df(float_t y) const override {
-        return y * (1.0 - y);
+        return y * (float_t(1) - y);
     }
 
     virtual vec_t df(const vec_t& y, size_t index) const override {
@@ -121,7 +121,7 @@ public:
         return v;
     }
 
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.0, 1.0); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0), float_t(1)); }
 };
 
 class tan_h : public function {
@@ -140,8 +140,8 @@ public:
         return x / std::sqrt(1.0 + x * x);// invsqrt(static_cast<float>(1.0 + x * x));
     }*/
 
-    float_t df(float_t y) const override { return 1.0 - sqr(y); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(-0.8, 0.8); }
+    float_t df(float_t y) const override { return float_t(1) - sqr(y); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(-0.8), float_t(0.8)); }
 
 private:
     /*float invsqrt(float x) const {
@@ -164,8 +164,8 @@ public:
         return ep / (ep + std::exp(-v[i]));
     }
 
-    float_t df(float_t y) const override { return 2 * y *(1.0 - y); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(0.1, 0.9); }
+    float_t df(float_t y) const override { return 2 * y *(float_t(1) - y); }
+    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 } // namespace activation

--- a/tiny_cnn/io/caffe/layer_factory_impl.h
+++ b/tiny_cnn/io/caffe/layer_factory_impl.h
@@ -129,9 +129,9 @@ inline std::shared_ptr<layer_base> create_ave_pool(int pool_size, int stride, co
     auto ap = std::make_shared<ave_pool>(bottom_shape.width_, bottom_shape.height_, bottom_shape.depth_, pool_size, stride);
 
     // tiny-cnn has trainable parameter in average-pooling layer
-    float_t weight = 1.0 / sqr(pool_size);
+    float_t weight = float_t(1) / sqr(pool_size);
     std::fill(ap->weight().begin(), ap->weight().end(), weight);
-    std::fill(ap->bias().begin(), ap->bias().end(), (float_t)0.0);
+    std::fill(ap->bias().begin(), ap->bias().end(), float_t(0));
     *top_shape = ap->out_shape();
     return ap;
 }
@@ -291,9 +291,9 @@ inline void load_weights_pool(const caffe::LayerParameter& src, layer_base *dst)
             pool_size = pool_param.kernel_size();
 
         // tiny-cnn has trainable parameter in average-pooling layer
-        float_t weight = 1.0 / sqr(pool_size);
+        float_t weight = float_t(1) / sqr(pool_size);
         if (!dst->weight().empty()) std::fill(dst->weight().begin(), dst->weight().end(), weight);
-        if (!dst->bias().empty()) std::fill(dst->bias().begin(), dst->bias().end(), (float_t)0.0);
+        if (!dst->bias().empty()) std::fill(dst->bias().begin(), dst->bias().end(), float_t(0));
     }
 }
 
@@ -326,7 +326,7 @@ inline std::shared_ptr<layer_base> create_dropout(const caffe::LayerParameter& l
     if (!layer.has_dropout_param())
         throw std::runtime_error("dropout param missing");
 
-    float_t dropout_rate = 0.5;
+    float_t dropout_rate = float_t(0.5);
 
     if (layer.dropout_param().has_dropout_ratio())
         dropout_rate = layer.dropout_param().dropout_ratio();

--- a/tiny_cnn/io/mnist_parser.h
+++ b/tiny_cnn/io/mnist_parser.h
@@ -77,7 +77,7 @@ inline void parse_mnist_image(std::ifstream& ifs,
     for (size_t y = 0; y < header.num_rows; y++)
       for (size_t x = 0; x < header.num_cols; x++)
         dst[width * (y + y_padding) + x + x_padding]
-        = (image_vec[y * header.num_cols + x] / 255.0) * (scale_max - scale_min) + scale_min;
+        = (image_vec[y * header.num_cols + x] / float_t(255)) * (scale_max - scale_min) + scale_min;
 }
 
 } // namespace detail

--- a/tiny_cnn/layers/average_pooling_layer.h
+++ b/tiny_cnn/layers/average_pooling_layer.h
@@ -42,7 +42,7 @@ public:
     average_pooling_layer(layer_size_t in_width, layer_size_t in_height, layer_size_t in_channels, layer_size_t pooling_size)
     : Base(in_width * in_height * in_channels, 
            in_width * in_height * in_channels / sqr(pooling_size), 
-           in_channels, in_channels, 1.0 / sqr(pooling_size)),
+           in_channels, in_channels, float_t(1) / sqr(pooling_size)),
       stride_(pooling_size),
       in_(in_width, in_height, in_channels), 
       out_(in_width/pooling_size, in_height/pooling_size, in_channels)
@@ -56,7 +56,7 @@ public:
     average_pooling_layer(layer_size_t in_width, layer_size_t in_height, layer_size_t in_channels, layer_size_t pooling_size, layer_size_t stride)
         : Base(in_width * in_height * in_channels,
             out_size(in_width, pooling_size, stride) * out_size(in_height, pooling_size, stride) * in_channels,
-            in_channels, in_channels, 1.0 / sqr(pooling_size)),
+            in_channels, in_channels, float_t(1) / sqr(pooling_size)),
         stride_(stride),
         in_(in_width, in_height, in_channels),
         out_(out_size(in_width, pooling_size, stride), out_size(in_height, pooling_size, stride), in_channels)
@@ -67,7 +67,7 @@ public:
         init_connection(pooling_size);
     }
 
-    image<> output_to_image(size_t worker_index = 0) const {
+    image<> output_to_image(size_t worker_index = 0) const override {
         return vec2image<unsigned char>(output_[worker_index], out_);
     }
 

--- a/tiny_cnn/layers/convolutional_layer.h
+++ b/tiny_cnn/layers/convolutional_layer.h
@@ -245,7 +245,7 @@ public:
         const activation::function& prev_h = prev_->activation_function();
         vec_t* prev_delta = (pad_type_ == padding::same) ? &prev_delta2_padded_ : &prev_delta2_;
 
-        std::fill(prev_delta->begin(), prev_delta->end(), (float_t)0.0);
+        std::fill(prev_delta->begin(), prev_delta->end(), float_t(0));
 
         // accumulate dw
         for_i(in_.depth_, [&](int inc) {
@@ -255,7 +255,7 @@ public:
 
                 for (layer_size_t wy = 0; wy < weight_.height_; wy++) {
                     for (layer_size_t wx = 0; wx < weight_.width_; wx++) {
-                        float_t dst = 0.0;
+                        float_t dst = float_t(0);
                         const float_t * prevo = &prev_out[in_padded_.get_index(wx, wy, inc)];
                         const float_t * delta = &current_delta2[out_.get_index(0, 0, outc)];
 
@@ -274,7 +274,7 @@ public:
         if (!this->bhessian_.empty()) {
             for (layer_size_t outc = 0; outc < out_.depth_; outc++) {
                 const float_t *delta = &current_delta2[out_.get_index(0, 0, outc)];
-                this->bhessian_[outc] += std::accumulate(delta, delta + out_.width_ * out_.height_, (float_t)0.0);
+                this->bhessian_[outc] += std::accumulate(delta, delta + out_.width_ * out_.height_, float_t(0));
             }
         }
 
@@ -325,7 +325,7 @@ public:
         vec_t &out = output_[worker_index]; // output
         const vec_t &in = *(prev_out_padded_[worker_index]); // input
         
-        std::fill(a.begin(), a.end(), (float_t)0.0);
+        std::fill(a.begin(), a.end(), float_t(0));
 
         for_i(parallelize_, out_.depth_, [&](int o) {
             for (layer_size_t inc = 0; inc < in_.depth_; inc++) {
@@ -339,7 +339,7 @@ public:
                     for (layer_size_t x = 0; x < out_.width_; x++) {
                         const float_t * ppw = pw;
                         const float_t * ppi = pi + (y * h_stride_) * in_padded_.width_ + x * w_stride_;
-                        float_t sum = (float_t)0.0;
+                        float_t sum = float_t(0);
 
                         // should be optimized for small kernel(3x3,5x5)
                         for (layer_size_t wy = 0; wy < weight_.height_; wy++) {
@@ -382,7 +382,7 @@ public:
         vec_t& dW = dW_[index];
         vec_t& db = db_[index];
 
-        std::fill(prev_delta->begin(), prev_delta->end(), (float_t)0.0);
+        std::fill(prev_delta->begin(), prev_delta->end(), float_t(0));
 
         // propagate delta to previous layer
         for_i(in_.depth_, [&](int inc) {
@@ -421,7 +421,7 @@ public:
 
                 for (layer_size_t wy = 0; wy < weight_.height_; wy++) {
                     for (layer_size_t wx = 0; wx < weight_.width_; wx++) {
-                        float_t dst = 0.0;
+                        float_t dst = float_t(0);
                         const float_t * prevo = &prev_out[in_padded_.get_index(wx, wy, inc)];
                         const float_t * delta = &curr_delta[out_.get_index(0, 0, outc)];
 
@@ -438,7 +438,7 @@ public:
         if (!db.empty()) {
             for (layer_size_t outc = 0; outc < out_.depth_; outc++) {
                 const float_t *delta = &curr_delta[out_.get_index(0, 0, outc)];
-                db[outc] += std::accumulate(delta, delta + out_.width_ * out_.height_, (float_t)0.0);
+                db[outc] += std::accumulate(delta, delta + out_.width_ * out_.height_, float_t(0));
             }
         }
 
@@ -494,15 +494,15 @@ private:
     void init() {
         for (layer_size_t i = 0; i < CNN_TASK_SIZE; i++) {
             if (pad_type_ == padding::same) {
-                prev_out_buf_[i] = new vec_t(in_padded_.size(), (float_t)0.0);
-                prev_delta_padded_[i].resize(in_padded_.size(), (float_t)0.0);               
+                prev_out_buf_[i] = new vec_t(in_padded_.size(), float_t(0));
+                prev_delta_padded_[i].resize(in_padded_.size(), float_t(0));               
             }
             else {
                 prev_out_buf_[i] = nullptr;
             }
         }
         if (pad_type_ == padding::same) {
-            prev_delta2_padded_.resize(in_padded_.size(), (float_t)0.0);
+            prev_delta2_padded_.resize(in_padded_.size(), float_t(0));
         }
     }
 

--- a/tiny_cnn/layers/convolutional_layer.h
+++ b/tiny_cnn/layers/convolutional_layer.h
@@ -28,7 +28,6 @@
 #include "tiny_cnn/util/util.h"
 #include "tiny_cnn/util/image.h"
 #include "tiny_cnn/activations/activation_function.h"
-#include "tiny_cnn/layers/partial_connected_layer.h"
 
 
 namespace tiny_cnn {
@@ -222,24 +221,24 @@ public:
     }
 
     ///< number of incoming connections for each output unit
-    virtual size_t fan_in_size() const
+    virtual size_t fan_in_size() const override
     {
         return weight_.width_ * weight_.height_ * in_.depth_;
     }
 
     ///< number of outgoing connections for each input unit
-    virtual size_t fan_out_size() const
+    virtual size_t fan_out_size() const override
     {
         return (weight_.width_ / w_stride_) * (weight_.height_ / h_stride_) * out_.depth_;
     }
 
     ///< number of connections
-    virtual size_t connection_size() const
+    virtual size_t connection_size() const override
     {
         return out_.size() * fan_in_size();
     }
 
-    virtual const vec_t& back_propagation_2nd(const vec_t& current_delta2)
+    virtual const vec_t& back_propagation_2nd(const vec_t& current_delta2) override
     {
         const vec_t& prev_out = *(prev_out_padded_[0]);
         const activation::function& prev_h = prev_->activation_function();
@@ -375,7 +374,7 @@ public:
         return W_[weight_.get_index(kernel_x, kernel_y, in_.depth_ * out_channel + in_channel)];
     }
 
-    const vec_t& back_propagation(const vec_t& curr_delta, size_t index) {
+    const vec_t& back_propagation(const vec_t& curr_delta, size_t index) override {
         const vec_t& prev_out = *(prev_out_padded_[index]);
         const activation::function& prev_h = prev_->activation_function();
         vec_t* prev_delta = (pad_type_ == padding::same) ? &prev_delta_padded_[index] : &prev_delta_[index];
@@ -574,6 +573,8 @@ private:
 };
 
 #if 0
+
+#include "tiny_cnn/layers/partial_connected_layer.h"
 
 template<typename Activation = activation::identity>
 class convolutional_layer : public partial_connected_layer<Activation> {

--- a/tiny_cnn/layers/dropout.h
+++ b/tiny_cnn/layers/dropout.h
@@ -61,7 +61,7 @@ namespace tiny_cnn {
         };
 
         explicit dropout(int out_dim)
-            : out_dim_(out_dim), mask_(out_dim), ctx_(train_phase), mode_(per_data), dropout_rate_(0.5) {
+            : out_dim_(out_dim), mask_(out_dim), ctx_(train_phase), mode_(per_data), dropout_rate_(float_t(0.5)) {
             for (int i = 0; i < CNN_TASK_SIZE; i++) {
                 masked_out_[i].resize(out_dim);
                 masked_delta_[i].resize(out_dim);
@@ -69,8 +69,8 @@ namespace tiny_cnn {
             shuffle();
         }
 
-        void set_dropout_rate(double rate) {
-            if (rate < 0.0 || rate >= 1.0)
+        void set_dropout_rate(float_t rate) {
+            if (rate < float_t(0) || rate >= float_t(1))
                 throw nn_error("0.0 <= dropout-rate < 1.0");
             dropout_rate_ = rate;
         }
@@ -91,7 +91,7 @@ namespace tiny_cnn {
             }
             else if (ctx_ == test_phase) {
                 for (int i = 0; i < out_dim_; i++)
-                    masked_out_[index][i] = out[i] * (1.0 - dropout_rate_);
+                    masked_out_[index][i] = out[i] * (float_t(1) - dropout_rate_);
             }
             else {
                 throw nn_error("invalid context");
@@ -111,7 +111,7 @@ namespace tiny_cnn {
 
         void shuffle() {
             for (auto& m : mask_)
-                m = bernoulli(1.0 - dropout_rate_);
+                m = bernoulli(float_t(1) - dropout_rate_);
         }
 
         void end_batch() {
@@ -125,7 +125,7 @@ namespace tiny_cnn {
         vec_t masked_delta_[CNN_TASK_SIZE];
         context ctx_;
         mode mode_;
-        double dropout_rate_;
+        float_t dropout_rate_;
     };
 
 } // namespace tiny_cnn

--- a/tiny_cnn/layers/dropout_layer.h
+++ b/tiny_cnn/layers/dropout_layer.h
@@ -57,6 +57,16 @@ public:
         std::copy(obj.mask_, (obj.mask_ + (in_size_ * CNN_TASK_SIZE)), mask_);
     }
 
+    dropout_layer(dropout_layer&& obj)
+        : layer<activation::identity>(obj.in_size_, obj.in_size_, 0, 0),
+          phase_(obj.phase_),
+          dropout_rate_(obj.dropout_rate_),
+          scale_(1.0 / (1.0 - dropout_rate_)),
+          mask_(obj.mask_)
+    {
+        obj.mask_ = nullptr;
+    }
+
     virtual ~dropout_layer()
     {
         delete[] mask_;
@@ -72,6 +82,16 @@ public:
         scale_ = obj.scale_;
         mask_ = new bool[in_size_ * CNN_TASK_SIZE];
         std::copy(obj.mask_, (obj.mask_ + (obj.in_size_ * CNN_TASK_SIZE)), mask_);
+        return *this;
+    }
+
+    dropout_layer& operator=(dropout_layer&& obj)
+    {
+        layer::operator=(obj);
+        phase_ = obj.phase_;
+        dropout_rate_ = obj.dropout_rate_;
+        scale_ = obj.scale_;
+        std::swap(mask_, obj.mask_);
         return *this;
     }
 

--- a/tiny_cnn/layers/dropout_layer.h
+++ b/tiny_cnn/layers/dropout_layer.h
@@ -41,7 +41,7 @@ public:
         : layer<activation::identity>(in_dim, in_dim, 0, 0),
           phase_(phase),
           dropout_rate_(dropout_rate),
-          scale_(1.0 / (1.0 - dropout_rate_))
+          scale_(float_t(1) / (float_t(1) - dropout_rate_))
     {
         mask_ = new bool[in_size_ * CNN_TASK_SIZE];
         std::fill(mask_, mask_ + (in_size_ * CNN_TASK_SIZE), false);
@@ -51,7 +51,7 @@ public:
         : layer<activation::identity>(obj.in_size_, obj.in_size_, 0, 0),
           phase_(obj.phase_),
           dropout_rate_(obj.dropout_rate_),
-          scale_(1.0 / (1.0 - dropout_rate_))
+          scale_(float_t(1) / (float_t(1) - dropout_rate_))
     {
         mask_ = new bool[in_size_ * CNN_TASK_SIZE];
         std::copy(obj.mask_, (obj.mask_ + (in_size_ * CNN_TASK_SIZE)), mask_);
@@ -61,7 +61,7 @@ public:
         : layer<activation::identity>(obj.in_size_, obj.in_size_, 0, 0),
           phase_(obj.phase_),
           dropout_rate_(obj.dropout_rate_),
-          scale_(1.0 / (1.0 - dropout_rate_)),
+          scale_(float_t(1) / (float_t(1) - dropout_rate_)),
           mask_(obj.mask_)
     {
         obj.mask_ = nullptr;
@@ -95,10 +95,10 @@ public:
         return *this;
     }
 
-    void set_dropout_rate(double rate)
+    void set_dropout_rate(float_t rate)
     {
         dropout_rate_ = rate;
-        scale_ = 1.0 / (1.0 - dropout_rate_);
+        scale_ = float_t(1) / (float_t(1) - dropout_rate_);
     }
 
     ///< number of incoming connections for each output unit

--- a/tiny_cnn/layers/fully_connected_layer.h
+++ b/tiny_cnn/layers/fully_connected_layer.h
@@ -57,7 +57,7 @@ public:
         vec_t &out = output_[index];
 
         for_i(parallelize_, out_size_, [&](int i) {
-            a[i] = 0.0;
+            a[i] = float_t(0);
             for (layer_size_t c = 0; c < in_size_; c++) {
                 a[i] += W_[c*out_size_ + i] * in[c];
             }
@@ -122,7 +122,7 @@ public:
         }
 
         for (layer_size_t c = 0; c < in_size_; c++) { 
-            prev_delta2_[c] = 0.0;
+            prev_delta2_[c] = float_t(0);
 
             for (layer_size_t r = 0; r < out_size_; r++) 
                 prev_delta2_[c] += current_delta2[r] * sqr(W_[c*out_size_ + r]);

--- a/tiny_cnn/layers/fully_connected_layer.h
+++ b/tiny_cnn/layers/fully_connected_layer.h
@@ -52,7 +52,7 @@ public:
         return out_size_;
     }
 
-    const vec_t& forward_propagation(const vec_t& in, size_t index) {
+    const vec_t& forward_propagation(const vec_t& in, size_t index) override {
         vec_t &a = a_[index];
         vec_t &out = output_[index];
 
@@ -74,7 +74,7 @@ public:
         return next_ ? next_->forward_propagation(out, index) : out;
     }
 
-    const vec_t& back_propagation(const vec_t& curr_delta, size_t index) {
+    const vec_t& back_propagation(const vec_t& curr_delta, size_t index) override {
         const vec_t& prev_out = prev_->output(index);
         const activation::function& prev_h = prev_->activation_function();
         vec_t& prev_delta = prev_delta_[index];
@@ -108,7 +108,7 @@ public:
         return prev_->back_propagation(prev_delta_[index], index);
     }
 
-    const vec_t& back_propagation_2nd(const vec_t& current_delta2) {
+    const vec_t& back_propagation_2nd(const vec_t& current_delta2) override {
         const vec_t& prev_out = prev_->output(0);
         const activation::function& prev_h = prev_->activation_function();
 

--- a/tiny_cnn/layers/input_layer.h
+++ b/tiny_cnn/layers/input_layer.h
@@ -43,16 +43,16 @@ public:
     index3d<layer_size_t> out_shape() const override { return next_ ? next_->out_shape() : index3d<layer_size_t>(0, 0, 0); }
     std::string layer_type() const override { return next_ ? next_->layer_type() : "input"; }
 
-    const vec_t& forward_propagation(const vec_t& in, size_t index) {
+    const vec_t& forward_propagation(const vec_t& in, size_t index) override {
         output_[index] = in;
         return next_ ? next_->forward_propagation(in, index) : output_[index];
     }
 
-    const vec_t& back_propagation(const vec_t& current_delta, size_t /*index*/) {
+    const vec_t& back_propagation(const vec_t& current_delta, size_t /*index*/) override {
         return current_delta;
     }
 
-    const vec_t& back_propagation_2nd(const vec_t& current_delta2) {
+    const vec_t& back_propagation_2nd(const vec_t& current_delta2) override {
         return current_delta2;
     }
 

--- a/tiny_cnn/layers/layer.h
+++ b/tiny_cnn/layers/layer.h
@@ -48,7 +48,7 @@ public:
     layer_base(layer_size_t in_dim, layer_size_t out_dim, size_t weight_dim, size_t bias_dim)
         : parallelize_(true), next_(nullptr), prev_(nullptr),
           weight_init_(std::make_shared<weight_init::xavier>()),
-          bias_init_(std::make_shared<weight_init::constant>(0.0)) {
+          bias_init_(std::make_shared<weight_init::constant>(float_t(0))) {
         set_size(in_dim, out_dim, weight_dim, bias_dim);
     }
 
@@ -69,8 +69,8 @@ public:
         weight_init_->fill(&W_, fan_in_size(), fan_out_size());
         bias_init_->fill(&b_, fan_in_size(), fan_out_size());
 
-        std::fill(Whessian_.begin(), Whessian_.end(), 0.0);
-        std::fill(bhessian_.begin(), bhessian_.end(), 0.0);
+        std::fill(Whessian_.begin(), Whessian_.end(), float_t(0));
+        std::fill(bhessian_.begin(), bhessian_.end(), float_t(0));
         clear_diff(CNN_TASK_SIZE);
     }
 
@@ -250,8 +250,8 @@ private:
 
     void clear_diff(size_t worker_size) {
         for (size_t i = 0; i < worker_size; i++) {
-            std::fill(dW_[i].begin(), dW_[i].end(), 0.0);
-            std::fill(db_[i].begin(), db_[i].end(), 0.0);
+            std::fill(dW_[i].begin(), dW_[i].end(), float_t(0));
+            std::fill(db_[i].begin(), db_[i].end(), float_t(0));
         }
     }
 

--- a/tiny_cnn/layers/linear_layer.h
+++ b/tiny_cnn/layers/linear_layer.h
@@ -43,7 +43,7 @@ public:
 
     typedef layer<Activation> Base;
 
-    explicit linear_layer(layer_size_t dim, float_t scale = 1.0, float_t bias = 0.0)
+    explicit linear_layer(layer_size_t dim, float_t scale = float_t(1), float_t bias = float_t(0))
         : Base(dim, dim, 0, 0),
         scale_(scale), bias_(bias) {}
 

--- a/tiny_cnn/layers/linear_layer.h
+++ b/tiny_cnn/layers/linear_layer.h
@@ -79,7 +79,7 @@ public:
         return next_ ? next_->forward_propagation(out, index) : out;
     }
 
-    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) {
+    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) override {
         const vec_t& prev_out = prev_->output(index);
         const activation::function& prev_h = prev_->activation_function();
         vec_t& prev_delta = prev_delta_[index];
@@ -91,7 +91,7 @@ public:
         return prev_->back_propagation(prev_delta_[index], index);
     }
 
-    const vec_t& back_propagation_2nd(const vec_t& current_delta2) {
+    const vec_t& back_propagation_2nd(const vec_t& current_delta2) override {
         const vec_t& prev_out = prev_->output(0);
         const activation::function& prev_h = prev_->activation_function();
 

--- a/tiny_cnn/layers/lrn_layer.h
+++ b/tiny_cnn/layers/lrn_layer.h
@@ -85,13 +85,13 @@ public:
         return next_ ? next_->forward_propagation(out, index) : out;
     }
 
-    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) {
+    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) override {
         CNN_UNREFERENCED_PARAMETER(current_delta);
         CNN_UNREFERENCED_PARAMETER(index);
         throw nn_error("not implemented");
     }
 
-    const vec_t& back_propagation_2nd(const vec_t& current_delta2) {
+    const vec_t& back_propagation_2nd(const vec_t& current_delta2) override {
         CNN_UNREFERENCED_PARAMETER(current_delta2);
         throw nn_error("not implemented");
     }

--- a/tiny_cnn/layers/lrn_layer.h
+++ b/tiny_cnn/layers/lrn_layer.h
@@ -98,7 +98,7 @@ public:
 
 private:
     void forward_across(const vec_t& in, vec_t& out) {
-        std::fill(in_square_.begin(), in_square_.end(), (float_t)0.0);
+        std::fill(in_square_.begin(), in_square_.end(), float_t(0));
 
         for (layer_size_t i = 0; i < size_ / 2; i++) {
             layer_size_t idx = in_shape_.get_index(0, 0, i);
@@ -121,7 +121,7 @@ private:
             float_t *dst = &out[in_shape_.get_index(0, 0, i)];
             const float_t *src = &in[in_shape_.get_index(0, 0, i)];
             for (layer_size_t j = 0; j < wxh; j++)
-                dst[j] = src[j] * std::pow(1.0 + alpha_div_size * in_square_[j], -beta_);
+                dst[j] = src[j] * std::pow(float_t(1) + alpha_div_size * in_square_[j], -beta_);
         }
     }
 

--- a/tiny_cnn/layers/max_pooling_layer.h
+++ b/tiny_cnn/layers/max_pooling_layer.h
@@ -77,7 +77,7 @@ public:
         return out2in_[0].size() * out2in_.size();
     }
 
-    virtual const vec_t& forward_propagation(const vec_t& in, size_t index) {
+    virtual const vec_t& forward_propagation(const vec_t& in, size_t index) override {
         vec_t& out = output_[index];
         vec_t& a = a_[index];
         std::vector<int>& max_idx = out2inmax_[index];
@@ -103,7 +103,7 @@ public:
         return next_ ? next_->forward_propagation(out, index) : out;
     }
 
-    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) {
+    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) override {
         const vec_t& prev_out = prev_->output(index);
         const activation::function& prev_h = prev_->activation_function();
         vec_t& prev_delta = prev_delta_[index];
@@ -118,7 +118,7 @@ public:
         return prev_->back_propagation(prev_delta_[index], index);
     }
 
-    const vec_t& back_propagation_2nd(const vec_t& current_delta2) {
+    const vec_t& back_propagation_2nd(const vec_t& current_delta2) override {
         const vec_t& prev_out = prev_->output(0);
         const activation::function& prev_h = prev_->activation_function();
 

--- a/tiny_cnn/layers/max_pooling_layer.h
+++ b/tiny_cnn/layers/max_pooling_layer.h
@@ -112,7 +112,7 @@ public:
         for_(parallelize_, 0, in_size_, [&](const blocked_range& r) {
             for (int i = r.begin(); i != r.end(); i++) {
                 int outi = in2out_[i];
-                prev_delta[i] = (max_idx[outi] == i) ? current_delta[outi] * prev_h.df(prev_out[i]) : 0.0;
+                prev_delta[i] = (max_idx[outi] == i) ? current_delta[outi] * prev_h.df(prev_out[i]) : float_t(0);
             }
         });
         return prev_->back_propagation(prev_delta_[index], index);
@@ -124,7 +124,7 @@ public:
 
         for (layer_size_t i = 0; i < in_size_; i++) {
             int outi = in2out_[i];
-            prev_delta2_[i] = (out2inmax_[0][outi] == i) ? current_delta2[outi] * sqr(prev_h.df(prev_out[i])) : 0.0;
+            prev_delta2_[i] = (out2inmax_[0][outi] == i) ? current_delta2[outi] * sqr(prev_h.df(prev_out[i])) : float_t(0);
         }
         return prev_->back_propagation_2nd(prev_delta2_);
     }

--- a/tiny_cnn/layers/partial_connected_layer.h
+++ b/tiny_cnn/layers/partial_connected_layer.h
@@ -108,7 +108,7 @@ public:
         return next_ ? next_->forward_propagation(output_[index], index) : output_[index]; // 15.6%
     }
 
-    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) {
+    virtual const vec_t& back_propagation(const vec_t& current_delta, size_t index) override {
         const vec_t& prev_out = prev_->output(index);
         const activation::function& prev_h = prev_->activation_function();
         vec_t& prev_delta = prev_delta_[index];
@@ -155,7 +155,7 @@ public:
         return prev_->back_propagation(prev_delta_[index], index);
     }
 
-    const vec_t& back_propagation_2nd(const vec_t& current_delta2) {
+    const vec_t& back_propagation_2nd(const vec_t& current_delta2) override {
         const vec_t& prev_out = prev_->output(0);
         const activation::function& prev_h = prev_->activation_function();
 

--- a/tiny_cnn/layers/partial_connected_layer.h
+++ b/tiny_cnn/layers/partial_connected_layer.h
@@ -40,7 +40,7 @@ public:
     typedef std::vector<std::pair<layer_size_t, layer_size_t> > wo_connections;
     typedef layer<Activation> Base;
 
-    partial_connected_layer(layer_size_t in_dim, layer_size_t out_dim, size_t weight_dim, size_t bias_dim, float_t scale_factor = 1.0)
+    partial_connected_layer(layer_size_t in_dim, layer_size_t out_dim, size_t weight_dim, size_t bias_dim, float_t scale_factor = float_t(1))
         : Base(in_dim, out_dim, weight_dim, bias_dim), 
           weight2io_(weight_dim), out2wi_(out_dim), in2wo_(in_dim), bias2out_(bias_dim), out2bias_(out_dim),
           scale_factor_(scale_factor) {}
@@ -88,7 +88,7 @@ public:
         for_i(parallelize_, out_size_, [&](int i) {
             const wi_connections& connections = out2wi_[i];
 
-            a[i] = 0.0;
+            a[i] = float_t(0);
 
             for (auto connection : connections)// 13.1%
                 a[i] += W_[connection.first] * in[connection.second]; // 3.2%
@@ -116,7 +116,7 @@ public:
         for_(parallelize_, 0, size_t(in_size_), [&](const blocked_range& r) {
             for (int i = r.begin(); i != r.end(); i++) {
                 const wo_connections& connections = in2wo_[i];
-                float_t delta = 0.0;
+                float_t delta = float_t(0);
 
                 for (auto connection : connections) 
                     delta += W_[connection.first] * current_delta[connection.second]; // 40.6%
@@ -128,7 +128,7 @@ public:
         for_(parallelize_, 0, weight2io_.size(), [&](const blocked_range& r) {
             for (int i = r.begin(); i < r.end(); i++) {
                 const io_connections& connections = weight2io_[i];
-                float_t diff = 0.0;
+                float_t diff = float_t(0);
 
                 for (auto connection : connections) // 11.9%
                     diff += prev_out[connection.first] * current_delta[connection.second];
@@ -139,7 +139,7 @@ public:
 
         for (size_t i = 0; i < bias2out_.size(); i++) {
             const std::vector<layer_size_t>& outs = bias2out_[i];
-            float_t diff = 0.0;
+            float_t diff = float_t(0);
 
             for (auto o : outs)
                 diff += current_delta[o];    
@@ -161,7 +161,7 @@ public:
 
         for (size_t i = 0; i < weight2io_.size(); i++) {
             const io_connections& connections = weight2io_[i];
-            float_t diff = 0.0;
+            float_t diff = float_t(0);
 
             for (auto connection : connections)
                 diff += sqr(prev_out[connection.first]) * current_delta2[connection.second];
@@ -172,7 +172,7 @@ public:
 
         for (size_t i = 0; i < bias2out_.size(); i++) {
             const std::vector<layer_size_t>& outs = bias2out_[i];
-            float_t diff = 0.0;
+            float_t diff = float_t(0);
 
             for (auto o : outs)
                 diff += current_delta2[o];    
@@ -182,7 +182,7 @@ public:
 
         for (layer_size_t i = 0; i < in_size_; i++) {
             const wo_connections& connections = in2wo_[i];
-            prev_delta2_[i] = 0.0;
+            prev_delta2_[i] = float_t(0);
 
             for (auto connection : connections) 
                 prev_delta2_[i] += sqr(W_[connection.first]) * current_delta2[connection.second];

--- a/tiny_cnn/lossfunctions/loss_function.h
+++ b/tiny_cnn/lossfunctions/loss_function.h
@@ -45,11 +45,11 @@ public:
 class cross_entropy {
 public:
     static float_t f(float_t y, float_t t) {
-        return -t * std::log(y) - (1.0 - t) * std::log(1.0 - y);
+        return -t * std::log(y) - (float_t(1) - t) * std::log(float_t(1) - y);
     }
 
     static float_t df(float_t y, float_t t) {
-        return (y - t) / (y * (1 - y));
+        return (y - t) / (y * (float_t(1) - y));
     }
 };
 

--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -224,7 +224,7 @@ public:
      * calculate loss value (the smaller, the better) for regression task
      **/
     float_t get_loss(const std::vector<vec_t>& in, const std::vector<vec_t>& t) {
-        float_t sum_loss = (float_t)0.0;
+        float_t sum_loss = float_t(0);
 
         for (size_t i = 0; i < in.size(); i++) {
             const vec_t predicted = predict(in[i]);
@@ -440,7 +440,7 @@ private:
     }
 
     float_t get_loss(const vec_t& out, const vec_t& t) {
-        float_t e = 0.0;
+        float_t e = float_t(0);
         assert(out.size() == t.size());
         for_i(out.size(), [&](int i){ e += E::f(out[i], t[i]); });
         return e;
@@ -481,20 +481,20 @@ private:
     float_t calc_delta(const vec_t* in, const vec_t* v, int data_size, vec_t& w, vec_t& dw, int check_index) {
         static const float_t delta = 1e-10;
 
-        std::fill(dw.begin(), dw.end(), 0.0);
+        std::fill(dw.begin(), dw.end(), float_t(0));
 
         // calculate dw/dE by numeric
         float_t prev_w = w[check_index];
 
         w[check_index] = prev_w + delta;
-        float_t f_p = 0.0;
+        float_t f_p = float_t(0);
         for_i(data_size, [&](int i){ f_p += get_loss(fprop(in[i]), v[i]); });
 
-        float_t f_m = 0.0;
+        float_t f_m = float_t(0);
         w[check_index] = prev_w - delta;
         for_i(data_size, [&](int i){ f_m += get_loss(fprop(in[i]), v[i]); });
 
-        float_t delta_by_numerical = (f_p - f_m) / (2.0 * delta);
+        float_t delta_by_numerical = (f_p - f_m) / (float_t(2) * delta);
         w[check_index] = prev_w;
 
         // calculate dw/dE by bprop

--- a/tiny_cnn/optimizers/optimizer.h
+++ b/tiny_cnn/optimizers/optimizer.h
@@ -38,9 +38,13 @@ template <bool usesHessian>
 struct optimizer {
     optimizer() = default;
     optimizer(const optimizer &) = default;
+#ifndef CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
     optimizer(optimizer &&) = default;
+#endif
     optimizer &operator =(const optimizer &) = default;
+#ifndef CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
     optimizer &operator =(optimizer &&) = default;
+#endif
     virtual ~optimizer() = default;
 
     bool requires_hessian() const { return usesHessian; } // vc2012 doesn't support constexpr

--- a/tiny_cnn/optimizers/optimizer.h
+++ b/tiny_cnn/optimizers/optimizer.h
@@ -78,7 +78,7 @@ protected:
  **/
 struct gradient_descent_levenberg_marquardt : public optimizer<true> {
 public:
-    gradient_descent_levenberg_marquardt() : alpha(0.00085), mu(0.02) {}
+    gradient_descent_levenberg_marquardt() : alpha(float_t(0.00085)), mu(float_t(0.02)) {}
 
     void update(const vec_t& dW, const vec_t& Hessian, vec_t& W) {
         for_i(W.size(), [&](int i){
@@ -98,7 +98,7 @@ public:
  * The Journal of Machine Learning Research, pages 2121-2159, 2011.
  **/
 struct adagrad : public stateful_optimizer<1, false> {
-    adagrad() : alpha(0.01), eps(1e-8) {}
+    adagrad() : alpha(float_t(0.01)), eps(float_t(1e-8)) {}
 
     void update(const vec_t& dW, const vec_t& /*Hessian*/, vec_t &W) {
         vec_t& g = get<0>(W);
@@ -121,7 +121,7 @@ private:
  * Lecture 6.5 - rmsprop, COURSERA: Neural Networks for Machine Learning (2012)
  **/
 struct RMSprop : public stateful_optimizer<1, false> {
-    RMSprop() : alpha(0.0001), mu(0.99), eps(1e-8) {}
+    RMSprop() : alpha(float_t(0.0001)), mu(float_t(0.99)), eps(float_t(1e-8)) {}
 
     void update(const vec_t& dW, const vec_t& /*Hessian*/, vec_t& W) {
         vec_t& g = get<0>(W);
@@ -147,7 +147,7 @@ private:
  * 
  */
 struct adam : public stateful_optimizer<2, false> {
-    adam() : alpha(0.001), b1(0.9), b2(0.999) , b1_t(0.9), b2_t(0.999), eps(1e-8) {}
+    adam() : alpha(float_t(0.001)), b1(float_t(0.9)), b2(float_t(0.999)), b1_t(float_t(0.9)), b2_t(float_t(0.999)), eps(float_t(1e-8)) {}
 
     void update(const vec_t& dW, const vec_t& /*Hessian*/, vec_t& W) {
         vec_t& mt = get<0>(W);
@@ -156,10 +156,10 @@ struct adam : public stateful_optimizer<2, false> {
         b1_t*=b1;b2_t*=b2;
 
         for_i(W.size(), [&](int i){
-            mt[i] = b1 * mt[i] + (1 - b1) * dW[i];
-            vt[i] = b2 * vt[i] + (1 - b2) * dW[i] * dW[i];
+            mt[i] = b1 * mt[i] + (float_t(1) - b1) * dW[i];
+            vt[i] = b2 * vt[i] + (float_t(1) - b2) * dW[i] * dW[i];
 
-            W[i] -= alpha * ( mt[i]/(1-b1_t) ) / std::sqrt( (vt[i]/(1-b2_t)) + eps);
+            W[i] -= alpha * ( mt[i]/(float_t(1) -b1_t) ) / std::sqrt( (vt[i]/(float_t(1)-b2_t)) + eps);
         });
     }
 
@@ -180,7 +180,7 @@ private:
  * slightly faster than tiny_cnn::momentum
  **/
 struct gradient_descent : public optimizer<false> {
-    gradient_descent() : alpha(0.01), lambda(0.0) {}
+    gradient_descent() : alpha(float_t(0.01)), lambda(float_t(0)) {}
 
     void update(const vec_t& dW, const vec_t& /*Hessian*/, vec_t& W) {
         for_i(W.size(), [&](int i){
@@ -201,7 +201,7 @@ struct gradient_descent : public optimizer<false> {
  **/
 struct momentum : public stateful_optimizer<1, false> {
 public:
-    momentum() : alpha(0.01), lambda(0.0), mu(0.9) {}
+    momentum() : alpha(float_t(0.01)), lambda(float_t(0)), mu(float_t(0.9)) {}
 
     void update(const vec_t& dW, const vec_t& /*Hessian*/, vec_t& W) {
         vec_t& dWprev = get<0>(W);

--- a/tiny_cnn/util/aligned_allocator.h
+++ b/tiny_cnn/util/aligned_allocator.h
@@ -65,7 +65,7 @@ public:
         return std::addressof(value);
     }
 
-    pointer allocate(size_type size, const void* = 0) {
+    pointer allocate(size_type size, const void* = nullptr) {
         void* p = aligned_alloc(alignment, sizeof(T) * size);
         if (!p && size > 0)
             throw nn_error("failed to allocate");

--- a/tiny_cnn/util/conv_kernel.h
+++ b/tiny_cnn/util/conv_kernel.h
@@ -207,7 +207,7 @@ namespace tiny_cnn {
     {
         assert(w_shape.depth_ == src_shape.depth_ * dst_shape.depth_);
 
-        std::fill(dst, dst + dst_shape.size(), (float_t)0.0);
+        std::fill(dst, dst + dst_shape.size(), float_t(0));
 
         for (int outc = 0; outc < dst_shape.depth_; outc++) {
             for (int inc = 0; inc < src_shape.depth_; inc++) {
@@ -215,7 +215,7 @@ namespace tiny_cnn {
 
                 for (int y = 0; y < dst_shape.height_; y++) {
                     for (int x = 0; x < dst_shape.width_; x++) {
-                        float_t sum = (float_t)0.0;
+                        float_t sum = float_t(0);
 
                         for (int ky = 0; ky < w_shape.height_; ky++)
                             for (int kx = 0; kx < w_shape.width_; kx++)

--- a/tiny_cnn/util/conv_kernel.h
+++ b/tiny_cnn/util/conv_kernel.h
@@ -67,7 +67,6 @@ namespace tiny_cnn {
         std::fill(dst, dst + dst_shape.size(), 0.0f);
 
         float *wtmp = (float*)malloc(sizeof(float) * w_shape.size());
-        float *dtmp = (float*)calloc(dst_shape.size(), sizeof(float));
         for (int inc = 0; inc < src_shape.depth_; inc++) {
             for (int outc = 0; outc < dst_shape.depth_; outc++) {
                 int oi0 = outc % VEC_WIDTH;

--- a/tiny_cnn/util/product.h
+++ b/tiny_cnn/util/product.h
@@ -64,7 +64,7 @@ struct generic_vec_type {
         unroll_size = 1
     };
     static register_type set1(const value_type& x) { return x; }
-    static register_type zero() { return 0.0; }
+    static register_type zero() { return register_type(0); }
     static register_type mul(const register_type& v1, const register_type& v2) { return v1 * v2; }
     static register_type add(const register_type& v1, const register_type& v2) { return v1 + v2; }
     static register_type load(const value_type* px) { return *px; }

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -353,3 +353,9 @@ void CNN_LOG_VECTOR(const vec_t& vec, const std::string& name) {
 */
 
 } // namespace tiny_cnn
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1800)
+#define CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
+#define CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
+#endif
+

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -90,8 +90,8 @@ inline int uniform_idx(const Container& t) {
     return uniform_rand(0, (int) t.size() - 1);
 }
 
-inline bool bernoulli(double p) {
-    return uniform_rand(0.0, 1.0) <= p;
+inline bool bernoulli(float_t p) {
+    return uniform_rand(float_t(0), float_t(1)) <= p;
 }
 
 template<typename Iter>

--- a/tiny_cnn/util/weight_init.h
+++ b/tiny_cnn/util/weight_init.h
@@ -91,7 +91,7 @@ public:
     gaussian() : scalable(float_t(1)) {}
     explicit gaussian(float_t sigma) : scalable(sigma) {}
 
-    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
+    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) override {
         CNN_UNREFERENCED_PARAMETER(fan_in);
         CNN_UNREFERENCED_PARAMETER(fan_out);
 
@@ -104,7 +104,7 @@ public:
     constant() : scalable(float_t(0)) {}
     explicit constant(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
+    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) override {
         CNN_UNREFERENCED_PARAMETER(fan_in);
         CNN_UNREFERENCED_PARAMETER(fan_out);
 
@@ -117,7 +117,7 @@ public:
     he() : scalable(float_t(2)) {}
     explicit he(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
+    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) override {
         CNN_UNREFERENCED_PARAMETER(fan_out);
 
         const float_t sigma = std::sqrt(scale_ /fan_in);

--- a/tiny_cnn/util/weight_init.h
+++ b/tiny_cnn/util/weight_init.h
@@ -55,7 +55,7 @@ protected:
  **/
 class xavier : public scalable {
 public:
-    xavier() : scalable((float_t)6.0) {}
+    xavier() : scalable(float_t(6)) {}
     explicit xavier(float_t value) : scalable(value) {}
 
     void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) override {
@@ -74,13 +74,13 @@ public:
  **/
 class lecun : public scalable {
 public:
-    lecun() : scalable((float_t)1.0) {}
+    lecun() : scalable(float_t(1)) {}
     explicit lecun(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
+    void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) override {
         CNN_UNREFERENCED_PARAMETER(fan_out);
 
-        const float_t weight_base = scale_ / std::sqrt(fan_in);
+        const float_t weight_base = scale_ / std::sqrt(float_t(fan_in));
 
         uniform_rand(weight->begin(), weight->end(), -weight_base, weight_base);
     }
@@ -88,20 +88,20 @@ public:
 
 class gaussian : public scalable {
 public:
-    gaussian() : scalable(1.0) {}
+    gaussian() : scalable(float_t(1)) {}
     explicit gaussian(float_t sigma) : scalable(sigma) {}
 
     void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
         CNN_UNREFERENCED_PARAMETER(fan_in);
         CNN_UNREFERENCED_PARAMETER(fan_out);
 
-        gaussian_rand(weight->begin(), weight->end(), 0.0, scale_);
+        gaussian_rand(weight->begin(), weight->end(), float_t(0), scale_);
     }
 };
 
 class constant : public scalable {
 public:
-    constant() : scalable((float_t)0.0) {}
+    constant() : scalable(float_t(0)) {}
     explicit constant(float_t value) : scalable(value) {}
 
     void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
@@ -114,7 +114,7 @@ public:
 
 class he : public scalable {
 public:
-    he() : scalable((float_t)2.0) {}
+    he() : scalable(float_t(2)) {}
     explicit he(float_t value) : scalable(value) {}
 
     void fill(vec_t *weight, layer_size_t fan_in, layer_size_t fan_out) {
@@ -122,7 +122,7 @@ public:
 
         const float_t sigma = std::sqrt(scale_ /fan_in);
 
-        gaussian_rand(weight->begin(), weight->end(), 0.0, sigma);
+        gaussian_rand(weight->begin(), weight->end(), float_t(0), sigma);
     }
 };
 


### PR DESCRIPTION
My previous PR broke pre-VS2013 compatibility (VS2013 doesn't allow defaulted move constructor).
Added a small utility for this in util.h (defining CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE and CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE in this case).
