### PR TITLE
Fix type cast warning

### DIFF
--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -171,7 +171,9 @@ public:
             if (optimizer_.requires_hessian())
                 calc_hessian(in);
             for (size_t i = 0; i < in.size(); i+=batch_size) {
-                train_once(&in[i], &t[i], std::min(batch_size, in.size() - i), n_threads);
+                train_once(&in[i], &t[i],
+                           static_cast<int>(std::min(batch_size, in.size() - i)),
+                           n_threads);
                 on_batch_enumerate();
 
                 if (i % 100 == 0 && layers_.is_exploded()) {

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -125,7 +125,7 @@ int max_index(const T& vec) {
 
     for (size_t i = 0; i < vec.size(); i++) {
         if (vec[i] > max_val) {
-            max_index = i;
+            max_index = static_cast<int>(i);
             max_val = vec[i];
         }
     }
@@ -199,20 +199,30 @@ void parallel_for(int begin, int end, const Func& f, int /*grainsize*/) {
 
 #endif // CNN_USE_TBB
 
-template<typename Func>
-void for_(bool parallelize, int begin, int end, Func f, int grainsize = 100) {
-    parallelize ? parallel_for(begin, end, f, grainsize) : xparallel_for(begin, end, f);
-}
-
 template<typename T, typename U>
 bool value_representation(U const &value) {
     return static_cast<U>(static_cast<T>(value)) == value;
 }
 
-template<typename Func>
-void for_(bool parallelize, int begin, size_t end, Func f, int grainsize = 100) {
+template<typename T, typename Func>
+inline
+void for_(std::true_type, bool parallelize, int begin, T end, Func f, int grainsize = 100){
     parallelize = parallelize && value_representation<int>(end);
+    parallelize ? parallel_for(begin, static_cast<int>(end), f, grainsize) :
+                  xparallel_for(begin, static_cast<int>(end), f);
+}
+
+template<typename T, typename Func>
+inline
+void for_(std::false_type, bool parallelize, int begin, T end, Func f, int grainsize = 100){
     parallelize ? parallel_for(begin, static_cast<int>(end), f, grainsize) : xparallel_for(begin, end, f);
+}
+
+template<typename T, typename Func>
+inline
+void for_(bool parallelize, int begin, T end, Func f, int grainsize = 100) {
+    static_assert(std::is_integral<T>::value, "end must be integral type");
+    for_(typename std::is_unsigned<T>::type(), parallelize, begin, end, f, grainsize);
 }
 
 template <typename Func>


### PR DESCRIPTION
Fix another type cast warning, I do some change on for_  function in the util.h too, please do not merge that part since it is over complicated, just merge following line

` max_index = static_cast<int>(i);`