### PR TITLE
Add travis-ci.org support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+sudo: false
+language: cpp
+os:
+  - linux
+  - osx
+compiler:
+  - gcc
+  - clang
+cache:
+  directories:
+  - $HOME/opencv_3_1_0 # Cache is only available on travis container-based boxes
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - boost-latest
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang
+    - cmake
+    - git
+    - libtbb-dev
+    - libboost1.55-all-dev
+    - libjpeg8-dev
+    - libtiff4-dev
+    - libjasper-dev
+    - libpng12-dev 
+    - libgtk2.0-dev
+    - libavcodec-dev
+    - libavformat-dev
+    - libswscale-dev
+    - libv4l-dev
+    - libatlas-base-dev
+    - gfortran
+install:
+  - bash -x .travis/install.sh 
+script:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export CPLUS_INCLUDE_PATH="$HOME/opencv_3_1_0/include"; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cmake -DUSE_TBB=ON -DUSE_AVX=OFF -DBUILD_TESTS=ON -DOpenCV_DIR="$HOME/opencv_3_1_0/share/OpenCV" .; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cmake -DUSE_TBB=ON -DUSE_AVX=OFF -DBUILD_TESTS=ON .; fi
+  - make -j2 
+  - ./tiny_cnn_test
+branches:
+  only:
+    - master
+matrix:
+  exclude: # On OSX g++ is a symlink to clang++ by default 
+    - os: osx
+      compiler: gcc

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  brew update >/dev/null
+  [ -z $( brew tap | grep 'homebrew/science' ) ] && brew tap homebrew/science
+  # TODO download homebrew-cache.tar.gz from s3 or similar to speed up the build
+  # Travis OSX boxes don't provide caching unfortunately
+  if [ -f "${HOME}/homebrew-cache/homebrew-cache.tar.gz" ]; then
+    tar -xvzf "${HOME}/homebrew-cache/homebrew-cache.tar.gz" --directory /usr/local/Cellar
+    brew link --force tbb boost cmake opencv3 jpeg libpng libtiff
+    brew install pkg-config
+  else
+    [ -z "$( brew ls --versions tbb )" ] && brew install --c++11 tbb
+    [ -z "$( brew ls --versions boost )" ] && brew install --c++11 boost
+    [ -z "$( brew ls --versions cmake )" ] && brew install cmake
+    [ -z "$( brew ls --versions opencv3 )" ] && brew install -v --c++11 --with-tbb --without-python --without-openexr --without-eigen --without-numpy opencv3 && brew link --force opencv3 # verbose flag prevents the build from going stale
+    mkdir "${HOME}/homebrew-cache"
+    tar -czvf "${HOME}/homebrew-cache/homebrew-cache.tar.gz" --directory /usr/local/Cellar tbb boost cmake opencv3 jpeg libpng libtiff
+  fi
+elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  version_major=3
+  version_minor=1
+  version_patch=0  
+  OPENCV_DIR="${HOME}/opencv_${version_major}_${version_minor}_${version_patch}"
+  if [ ! -d  "${OPENCV_DIR}/lib" ]; then
+    git clone https://github.com/Itseez/opencv.git
+    cd opencv
+    git checkout ${version_major}.${version_minor}.${version_patch}
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$OPENCV_DIR" ..
+    make -j2 && make -j2 install
+  else
+    echo "Cached OpenCV ${1}.${2}.${3} found";
+  fi
+fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ OPTION(USE_TBB 	"Set to ON to use boost" OFF)
 OPTION(USE_OMP 	"Set to ON to use boost" OFF)
 OPTION(USE_SSE 	"Set to ON to use sse" ON)
 OPTION(USE_AVX 	"Set to ON to use avx" ON)
+OPTION(BUILD_TESTS "Set to ON to build tests" OFF)
 
 # ----------------------------------------------------------------------------
 #   Find Dependencies
@@ -132,6 +133,12 @@ IF(Boost_FOUND)
 ENDIF()
 ADD_EXECUTABLE(testb examples/mnist/test.cpp  ${tiny_cnn_hrds})
 target_link_libraries( testb ${OpenCV_LIBS} )
+
+IF(BUILD_TESTS)
+    FIND_PACKAGE(Boost COMPONENTS system filesystem REQUIRED)
+    ADD_EXECUTABLE(tiny_cnn_test test/test.cpp ${tiny_cnn_hrds})
+    TARGET_LINK_LIBRARIES(tiny_cnn_test ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
+ENDIF()
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ ENDIF()
 # COMPILER OPTIONS
 # ----------------------------------------------------------------------------
 
-IF(CMAKE_COMPILER_IS_GNUCXX OR MINGW)
+IF(CMAKE_COMPILER_IS_GNUCXX OR MINGW OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     IF(USE_SSE)
         add_definitions(-DCNN_USE_SSE)
         SET(EXTRA_C_FLAGS  " ${EXTRA_C_FLAGS} -msse3 ")

--- a/test/picotest.h
+++ b/test/picotest.h
@@ -39,6 +39,7 @@
 #include <stdint.h>
 #include <cstdarg>
 #include <cstring>
+#include <cmath>
 
 #if defined _WIN32 
 #define PICOTEST_WINDOWS

--- a/tiny_cnn/layers/max_pooling_layer.h
+++ b/tiny_cnn/layers/max_pooling_layer.h
@@ -109,7 +109,7 @@ public:
         vec_t& prev_delta = prev_delta_[index];
         std::vector<int>& max_idx = out2inmax_[index];
 
-        for_(parallelize_, 0, in_size_, [&](const blocked_range& r) {
+        for_(parallelize_, 0, size_t(in_size_), [&](const blocked_range& r) {
             for (int i = r.begin(); i != r.end(); i++) {
                 int outi = in2out_[i];
                 prev_delta[i] = (max_idx[outi] == i) ? current_delta[outi] * prev_h.df(prev_out[i]) : 0.0;


### PR DESCRIPTION
- Compiles and runs tiny-cnn/test/test.cpp picotest
- Tests under linux with gcc-4.8 and clang 3.4
- Tests under OSX with Apple LLVM clang 6.0 (based on clang 3.5)
- Tests master branch only
- Uses CMake for config and compilation

**TODO:**
- Host homebrew-cache.tar.gz somewhere like s3 to speed up the build on
  OSX (Currently 15 minutes)
- The picotest exists with code 0 on failure. Should be code 1 for the
  build to break on travis-ci.
- Check why some picotests fail.