### PR TITLE
Nyanp master

### DIFF
--- a/tiny_cnn/config.h
+++ b/tiny_cnn/config.h
@@ -47,6 +47,11 @@
 //#define CNN_USE_OMP
 
 /**
+ * define to use exceptions
+ */
+#define CNN_USE_EXCEPTIONS
+
+/**
  * number of task in batch-gradient-descent.
  * @todo automatic optimization
  */

--- a/tiny_cnn/layers/layer.h
+++ b/tiny_cnn/layers/layer.h
@@ -260,7 +260,7 @@ private:
     }
 
     void set_size(layer_size_t in_dim, layer_size_t out_dim, size_t weight_dim, size_t bias_dim) {
-        try {
+        CNN_TRY {
             in_size_ = in_dim;
             out_size_ = out_dim;
 
@@ -275,7 +275,7 @@ private:
             for (auto& p : prev_delta_) p.resize(in_dim);
             for (auto& dw : dW_) dw.resize(weight_dim);
             for (auto& db : db_) db.resize(bias_dim);
-        } catch (const std::bad_alloc&) {
+        } CNN_CATCH (const std::bad_alloc&) {
             throw nn_error(
                 format_str("memory allocation failed: layer size too large!\nin:%d,out:%d,weights:%d,biases:%d",
                            in_dim, out_dim, weight_dim, bias_dim));

--- a/tiny_cnn/layers/layer.h
+++ b/tiny_cnn/layers/layer.h
@@ -260,26 +260,20 @@ private:
     }
 
     void set_size(layer_size_t in_dim, layer_size_t out_dim, size_t weight_dim, size_t bias_dim) {
-        CNN_TRY {
-            in_size_ = in_dim;
-            out_size_ = out_dim;
+        in_size_ = in_dim;
+        out_size_ = out_dim;
 
-            W_.resize(weight_dim);
-            b_.resize(bias_dim);
-            Whessian_.resize(weight_dim);
-            bhessian_.resize(bias_dim);
-            prev_delta2_.resize(in_dim);
+        W_.resize(weight_dim);
+        b_.resize(bias_dim);
+        Whessian_.resize(weight_dim);
+        bhessian_.resize(bias_dim);
+        prev_delta2_.resize(in_dim);
 
-            for (auto& o : output_)     o.resize(out_dim);
-            for (auto& a : a_)          a.resize(out_dim);
-            for (auto& p : prev_delta_) p.resize(in_dim);
-            for (auto& dw : dW_) dw.resize(weight_dim);
-            for (auto& db : db_) db.resize(bias_dim);
-        } CNN_CATCH (const std::bad_alloc&) {
-            throw nn_error(
-                format_str("memory allocation failed: layer size too large!\nin:%d,out:%d,weights:%d,biases:%d",
-                           in_dim, out_dim, weight_dim, bias_dim));
-        }
+        for (auto& o : output_)     o.resize(out_dim);
+        for (auto& a : a_)          a.resize(out_dim);
+        for (auto& p : prev_delta_) p.resize(in_dim);
+        for (auto& dw : dW_) dw.resize(weight_dim);
+        for (auto& db : db_) db.resize(bias_dim);
     }
 };
 

--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -127,6 +127,19 @@ public:
     vec_t        predict(const vec_t& in) { return fprop(in); }
 
     /**
+     * executes forward-propagation and returns maximum output
+     **/
+    float_t      predict_max_value(const vec_t& in) {
+        return fprop_max(in);
+    }
+    /**
+     * executes forward-propagation and returns maximum output index
+     **/
+    label_t      predict_label(const vec_t& in) {
+        return fprop_max_index(in);
+    }
+
+    /**
      * executes forward-propagation and returns output
      *
      * @param in input value range(double[], std::vector<double>, std::list<double> etc)
@@ -201,7 +214,7 @@ public:
         result test_result;
 
         for (size_t i = 0; i < in.size(); i++) {
-            const label_t predicted = max_index(predict(in[i]));
+            const label_t predicted = fprop_max_index(in[i]);
             const label_t actual = t[i];
 
             if (predicted == actual) test_result.num_success++;
@@ -370,6 +383,15 @@ public:
         return *this;
     }
 
+protected:
+    float_t fprop_max(const vec_t& in, int idx = 0) {
+        const vec_t& prediction = fprop(in, idx);
+        return *std::max_element(std::begin(prediction), std::end(prediction));
+    }
+
+    label_t fprop_max_index(const vec_t& in, int idx = 0) {
+        return label_t(max_index(fprop(in, idx)));
+    }
 private:
 
     void label2vector(const label_t* t, int num, std::vector<vec_t> *vec) const {

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -121,17 +121,9 @@ inline bool is_little_endian() {
 
 
 template<typename T>
-int max_index(const T& vec) {
-    typename T::value_type max_val = std::numeric_limits<typename T::value_type>::lowest();
-    int max_index = -1;
-
-    for (size_t i = 0; i < vec.size(); i++) {
-        if (vec[i] > max_val) {
-            max_index = static_cast<int>(i);
-            max_val = vec[i];
-        }
-    }
-    return max_index;
+size_t max_index(const T& vec) {
+    auto begin_iterator = std::begin(vec);
+    return std::max_element(begin_iterator, std::end(vec)) - begin_iterator;
 }
 
 template<typename T, typename U>

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -34,10 +34,9 @@
 #include <cstdio>
 #include <cstdarg>
 #include <string>
-#include <thread>
-#include <future>
 #include "aligned_allocator.h"
 #include "nn_error.h"
+#include "tiny_cnn/config.h"
 
 #ifdef CNN_USE_TBB
 #ifndef NOMINMAX
@@ -45,6 +44,11 @@
 #endif
 #include <tbb/tbb.h>
 #include <tbb/task_group.h>
+#endif
+
+#ifndef CNN_USE_OMP
+#include <thread>
+#include <future>
 #endif
 
 #define CNN_UNREFERENCED_PARAMETER(x) (void)(x)
@@ -89,7 +93,7 @@ gaussian_rand(T mean, T sigma) {
 
 template<typename Container>
 inline int uniform_idx(const Container& t) {
-    return uniform_rand(0, (int) t.size() - 1);
+    return uniform_rand(0, int(t.size() - 1));
 }
 
 inline bool bernoulli(float_t p) {
@@ -376,3 +380,10 @@ void CNN_LOG_VECTOR(const vec_t& vec, const std::string& name) {
 #define CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
 #endif
 
+#ifdef CNN_USE_EXCEPTIONS
+#define CNN_TRY try
+#define CNN_CATCH(x) catch(x)
+#else
+#define CNN_TRY
+#define CNN_CATCH(x) if (true) ; else
+#endif

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -379,11 +379,3 @@ void CNN_LOG_VECTOR(const vec_t& vec, const std::string& name) {
 #define CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
 #define CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
 #endif
-
-#ifdef CNN_USE_EXCEPTIONS
-#define CNN_TRY try
-#define CNN_CATCH(x) catch(x)
-#else
-#define CNN_TRY
-#define CNN_CATCH(x) if (true) ; else
-#endif

--- a/vc/tiny_cnn_test.vcxproj
+++ b/vc/tiny_cnn_test.vcxproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Changed definition of max_index to use max_element
Introduced fprop_max and fprop_max_index protected functions, and their respective public counterpart predict_max_value and predict_label (better naming suggestions are welcome).
Added configuration option to opt-in the use of exceptions (CNN_USE_EXCEPTION, enabled by default in config.h), added inclusion of config.h from util.h.
Moved the inclusion of future and thread under a ifndef CNN_USE_OMP, to avoid warnings related to use of exception mechanism in VS2015 with exception handling disabled (and warning level 4).