### PR TITLE
Parametrizing VECTORIZE_TYPE

### DIFF
--- a/tiny_cnn/util/product.h
+++ b/tiny_cnn/util/product.h
@@ -281,38 +281,38 @@ inline void reduce_aligned(const typename T::value_type* src, unsigned int size,
 } // namespace detail
 
 #if defined(CNN_USE_AVX)
-#define VECTORIZE_TYPE detail::avx<T>
+#define VECTORIZE_TYPE(T) detail::avx<T>
 #elif defined(CNN_USE_SSE)
-#define VECTORIZE_TYPE detail::sse<T>
+#define VECTORIZE_TYPE(T) detail::sse<T>
 #else
-#define VECTORIZE_TYPE detail::generic_vec_type<T>
+#define VECTORIZE_TYPE(T) detail::generic_vec_type<T>
 #endif
 
 // dst[i] += c * src[i]
 template<typename T>
 void muladd(const T* src, T c, unsigned int size, T* dst) {
-    if (detail::is_aligned(VECTORIZE_TYPE(), src, dst))
-        detail::muladd_aligned<VECTORIZE_TYPE>(src, c, size, dst);
+    if (detail::is_aligned(VECTORIZE_TYPE(T)(), src, dst))
+        detail::muladd_aligned<VECTORIZE_TYPE(T)>(src, c, size, dst);
     else
-        detail::muladd_nonaligned<VECTORIZE_TYPE>(src, c, size, dst);
+        detail::muladd_nonaligned<VECTORIZE_TYPE(T)>(src, c, size, dst);
 }
 
 // sum(s1[i] * s2[i])
 template<typename T>
 T dot(const T* s1, const T* s2, unsigned int size) {
-    if (detail::is_aligned(VECTORIZE_TYPE(), s1, s2))
-        return detail::dot_product_aligned<VECTORIZE_TYPE>(s1, s2, size);
+    if (detail::is_aligned(VECTORIZE_TYPE(T)(), s1, s2))
+        return detail::dot_product_aligned<VECTORIZE_TYPE(T)>(s1, s2, size);
     else
-        return detail::dot_product_nonaligned<VECTORIZE_TYPE>(s1, s2, size);
+        return detail::dot_product_nonaligned<VECTORIZE_TYPE(T)>(s1, s2, size);
 }
 
 /// dst[i] += src[i]
 template<typename T>
 void reduce(const T* src, unsigned int size, T* dst) {
-    if (detail::is_aligned(VECTORIZE_TYPE(), src, dst))
-        return detail::reduce_aligned<VECTORIZE_TYPE>(src, size, dst);
+    if (detail::is_aligned(VECTORIZE_TYPE(T)(), src, dst))
+        return detail::reduce_aligned<VECTORIZE_TYPE(T)>(src, size, dst);
     else
-        return detail::reduce_nonaligned<VECTORIZE_TYPE>(src, size, dst);
+        return detail::reduce_nonaligned<VECTORIZE_TYPE(T)>(src, size, dst);
 }
 
 } // namespace vectorize


### PR DESCRIPTION
I parametrized the macro VECTORIZE_TYPE (when inspecting possible actions for cuDNN implementation, I found out that I had to use T as generic type for my template).

One drawback of this approach is that it cannot be used if T is a type whose representation includes a comma (such as a templated type with two template parameters).

A different (more C++11ish) approach would be to use templated usings, such as

template<typename T> using vectorize_type = detail::avx<T>;

and use vectorize_type<T> in place of VECTORIZE_TYPE (or VECTORIZE_TYPE(T) in my PR).

I remember a year ago a PR was partially rejected when replacing typedefs with usings, but the reason was compatibility with VS2012, which we dropped.
Let me know if I should produce a different version with using(s).