### PR TITLE
Fix build problem due to missing header for size_t

### DIFF
--- a/tiny_cnn/config.h
+++ b/tiny_cnn/config.h
@@ -25,6 +25,7 @@
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
+#include <cstddef>
 
 /**
  * define if you want to use intel TBB library


### PR DESCRIPTION
I get this error when compiling with clang 3.7.1:

    ./tiny_cnn/config.h:76:9: error: 'size_t' does not name a type
     typedef size_t cnn_size_t;

Including the header for size_t should fix this.