### PR TITLE
Made convolutional_layer::out_size/out_length static

### DIFF
--- a/tiny_cnn/layers/convolutional_layer.h
+++ b/tiny_cnn/layers/convolutional_layer.h
@@ -509,11 +509,11 @@ private:
         return pad_type == padding::same ? (in_length + window_size - 1) : in_length;
     }
 
-    cnn_size_t out_length(cnn_size_t in_length, cnn_size_t window_size, cnn_size_t stride, padding pad_type) const {
+    static cnn_size_t out_length(cnn_size_t in_length, cnn_size_t window_size, cnn_size_t stride, padding pad_type) {
         return pad_type == padding::same ? (cnn_size_t)ceil((double)in_length / stride) : (cnn_size_t)ceil((double)(in_length - window_size + 1) / stride);
     }
 
-    cnn_size_t out_size(cnn_size_t in_width, cnn_size_t in_height, cnn_size_t window_size, cnn_size_t w_stride, cnn_size_t h_stride, padding pad_type) const {
+    static cnn_size_t out_size(cnn_size_t in_width, cnn_size_t in_height, cnn_size_t window_size, cnn_size_t w_stride, cnn_size_t h_stride, padding pad_type) {
         return out_length(in_width, window_size, w_stride, pad_type) * out_length(in_height, window_size, h_stride, pad_type);
     }
 


### PR DESCRIPTION
clangs UBSAN report:

    tiny_cnn/tiny-cnn/tiny_cnn/layers/convolutional_layer.h:101:60: runtime error: member call on address 0x7fffffffcfe0 which does not point to an object of type 'convolutional_layer'
    0x7fffffffcfe0: note: object has invalid vptr
     00 00 00 00  f0 cf ff ff ff 7f 00 00  00 00 00 00 00 00 00 00  00 d1 ff ff ff 7f 00 00  58 5e f9 f7
                  ^~~~~~~~~~~~~~~~~~~~~~~
                  invalid vptr

Not calling a member function before the base class constructor is called should fix this. I made the functions static (which doesn't seem to break the API as far as I can see) for this reason.