### PR TITLE
Fixed unsigned underflow in lrn_layer.h

### DIFF
--- a/tiny_cnn/layers/lrn_layer.h
+++ b/tiny_cnn/layers/lrn_layer.h
@@ -106,7 +106,7 @@ private:
         }
 
         cnn_size_t head = size_ / 2;
-        cnn_size_t tail = head - size_;
+        long tail = ((long) head) - size_;
         cnn_size_t channels = in_shape_.depth_;
         const cnn_size_t wxh = in_shape_.area();
         const float_t alpha_div_size = alpha_ / size_;


### PR DESCRIPTION
Should fix the failing tests. There are probably nicer ways to do this, but I guess just throwing big integers at the problem is ok for now :).