### PR TITLE
Improve load performace

### DIFF
--- a/tiny_cnn/layers/layer.h
+++ b/tiny_cnn/layers/layer.h
@@ -161,6 +161,11 @@ public:
         for (auto& w : W_) is >> w;
         for (auto& b : b_) is >> b;
     }
+    
+    virtual void load(std::vector<double> weights, int& idx) {
+		for (auto& w : W_) w = weights[idx++];
+		for (auto& b : b_) b = weights[idx++];
+	}
 
     /////////////////////////////////////////////////////////////////////////
     // visualize

--- a/tiny_cnn/layers/layer.h
+++ b/tiny_cnn/layers/layer.h
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <iomanip>
 #include <memory>
+#include <stdio.h>
 #include "tiny_cnn/util/util.h"
 #include "tiny_cnn/util/product.h"
 #include "tiny_cnn/util/image.h"

--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -282,7 +282,29 @@ public:
         auto l = layers_.head();
         while (l) { l->load(is); l = l->next(); }
     }
+    
+    /**
+     * load network weights from filepath, 30 times faster than stream reading
+     * @attention this loads only network *weights*, not network configuration
+     **/
+    void fast_load(const char* filepath) {
+		FILE* stream = fopen(filepath, "r");
+		//double* temp = new double[param_num];
+		//const double* data = temp;
+		vector<double> data;
+		double temp;
+		while (fscanf(stream, "%lf", &temp) > 0)
+			data.push_back(temp);
+		fclose(stream);
 
+		auto l = layers_.head();
+		int idx = 0;
+		while (l) {
+			l->load(data, idx);
+			l = l->next();
+		}
+	}
+    
     /**
      * checking gradients calculated by bprop
      * detail information:

--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -291,7 +291,7 @@ public:
 		FILE* stream = fopen(filepath, "r");
 		//double* temp = new double[param_num];
 		//const double* data = temp;
-		vector<double> data;
+		std::vector<double> data;
 		double temp;
 		while (fscanf(stream, "%lf", &temp) > 0)
 			data.push_back(temp);


### PR DESCRIPTION
Hi,
When I use this framework in my program, the time of a loading a 8-layers-weights-file(1400258 params) runs up to 27 second.

So I add fast_load function. Same task, the time goes down to 0.8 second. 
I think this maybe helpful for someone who cares about running time.

Just a little code, easy to merge