### PR TITLE
Problem: the xor function test fails in my environment

### DIFF
--- a/test/test_network.h
+++ b/test/test_network.h
@@ -83,7 +83,7 @@ TEST(network, train_predict) {
 
     std::vector<vec_t> data;
     std::vector<label_t> label;
-    size_t tnum = 100;
+    size_t tnum = 200;
 
     net.optimizer().alpha *= 10;
 


### PR DESCRIPTION
Solution: increase the number of training samples
  (alternatively, increasing the number of epochs appeared to work as well)