### PR TITLE
Added the set_worker_count() call to other maxpoollayer constructor.

### DIFF
--- a/tiny_cnn/layers/max_pooling_layer.h
+++ b/tiny_cnn/layers/max_pooling_layer.h
@@ -49,9 +49,7 @@ public:
     {
         if ((in_width % pooling_size) || (in_height % pooling_size))
             pooling_size_mismatch(in_width, in_height, pooling_size);
-
         set_worker_count(CNN_TASK_SIZE);
-
         init_connection();
     }
 
@@ -64,6 +62,7 @@ public:
         in_(in_width, in_height, in_channels),
         out_(pool_out_dim(in_width, pooling_size, stride), pool_out_dim(in_height, pooling_size, stride), in_channels)
     {
+        set_worker_count(CNN_TASK_SIZE);
         init_connection();
     }
 


### PR DESCRIPTION
The overloaded constructor for the max_pooling_layer.h is missing the set_worker_count() call. So when the forward_propagation() is executed, the max_pooling_layer_worker_storage_ is empty and accessed, causing the problem described in issue #143.