### PR TITLE
Duplicate symbols fix and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ ENDIF()
 
 
 IF(BUILD_TESTS)
-    ADD_EXECUTABLE(tiny_cnn_test test/test.cpp ${tiny_cnn_hdrs} ${tiny_cnn_test_headers})
+    ADD_EXECUTABLE(tiny_cnn_test test/test.cpp test/test_no_duplicate_symbols.cpp  ${tiny_cnn_hdrs} ${tiny_cnn_test_headers})
 ENDIF()
 
 #------------------------------------------------

--- a/test/test_no_duplicate_symbols.cpp
+++ b/test/test_no_duplicate_symbols.cpp
@@ -1,0 +1,37 @@
+/*
+    Copyright (c) 2013, Taiga Nomi
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _CRT_SECURE_NO_WARNINGS
+#include "picotest/picotest.h"
+#include "tiny_cnn/tiny_cnn.h"
+
+TEST(no_duplicate_symbols, no_duplicate_symbols) { 
+    // The real test is that the tests link without errors due to duplicate symbols
+    // typically caused by missing inline keywords in headers.
+    // This is why this test is placed in a separate .cpp file.
+    EXPECT_TRUE(true);
+}

--- a/tiny_cnn/network.h
+++ b/tiny_cnn/network.h
@@ -893,12 +893,12 @@ std::basic_istream<Char, CharTraits>& operator >> (std::basic_istream<Char, Char
     return os;
 }
 
-void construct_graph(network<graph>& graph, const std::vector<layer*>& inputs, const std::vector<layer*>& outputs)
+inline void construct_graph(network<graph>& graph, const std::vector<layer*>& inputs, const std::vector<layer*>& outputs)
 {
     graph.net_.construct(inputs, outputs);
 }
 
-void construct_graph(network<graph>& graph, const std::vector<std::shared_ptr<layer>>& inputs, const std::vector<std::shared_ptr<layer>>& outputs)
+inline void construct_graph(network<graph>& graph, const std::vector<std::shared_ptr<layer>>& inputs, const std::vector<std::shared_ptr<layer>>& outputs)
 {
     std::vector<layer*> in_ptr, out_ptr;
     auto shared2ptr = [](std::shared_ptr<layer> l) { return l.get(); };

--- a/tiny_cnn/node.h
+++ b/tiny_cnn/node.h
@@ -159,7 +159,7 @@ class edge {
     std::vector<node*> next_;  // next nodes, "consumers" of this tensor
 };
 
-std::vector<node*> node::prev_nodes() const {
+inline std::vector<node*> node::prev_nodes() const {
     std::set<node*> sets;
     for (auto& e : prev_) {
         if (e && e->prev()) sets.insert(e->prev());
@@ -167,7 +167,7 @@ std::vector<node*> node::prev_nodes() const {
     return std::vector<node*>(sets.begin(), sets.end());
 }
 
-std::vector<node*> node::next_nodes() const {
+inline std::vector<node*> node::next_nodes() const {
     std::set<node*> sets;
     for (auto& e : next_) {
         if (e) {

--- a/tiny_cnn/util/util.h
+++ b/tiny_cnn/util/util.h
@@ -112,7 +112,7 @@ gaussian_rand(T mean, T sigma) {
     return dst(random_generator::get_instance()());
 }
 
-void set_random_seed(unsigned int seed) {
+inline void set_random_seed(unsigned int seed) {
     random_generator::get_instance().set_seed(seed);
 }
 


### PR DESCRIPTION
I discovered some link errors due to duplicate symbols when I upgraded to 0.1.0. This happens for me because I'm using the tiny cnn headers in more than one translation unit. 

This pull request contains some inline keywords to fix the link errors and an added .cpp file included in the tiny_cnn_test in order to try and catch this type of error when they are introduced.