### PR TITLE
fix a compile error and warnings when the type float_t is a typedef of float

### DIFF
--- a/examples/cifar10/train.cpp
+++ b/examples/cifar10/train.cpp
@@ -80,7 +80,7 @@ void train_cifar10(string data_dir_path, double learning_rate, ostream& log) {
     const int n_minibatch = 10; ///< minibatch size
     const int n_train_epochs = 30; ///< training duration
 
-    optimizer.alpha *= sqrt(n_minibatch) * learning_rate;
+    optimizer.alpha *= static_cast<tiny_cnn::float_t>(sqrt(n_minibatch) * learning_rate);
 
     // create callback
     auto on_enumerate_epoch = [&]() {

--- a/examples/deconv/train.cpp
+++ b/examples/deconv/train.cpp
@@ -86,7 +86,7 @@ void train_lenet(std::string data_dir_path) {
     int minibatch_size = 10;
     int num_epochs = 30;
 
-    optimizer.alpha *= std::sqrt(minibatch_size);
+    optimizer.alpha *= static_cast<tiny_cnn::float_t>(std::sqrt(minibatch_size));
 
     // create callback
     auto on_enumerate_epoch = [&](){

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -84,7 +84,7 @@ void train_lenet(std::string data_dir_path) {
     int minibatch_size = 10;
     int num_epochs = 30;
 
-    optimizer.alpha *= std::sqrt(minibatch_size);
+    optimizer.alpha *= static_cast<tiny_cnn::float_t>(std::sqrt(minibatch_size));
 
     // create callback
     auto on_enumerate_epoch = [&](){

--- a/tiny_cnn/layers/layer.h
+++ b/tiny_cnn/layers/layer.h
@@ -225,7 +225,7 @@ class layer : public node {
      * used only for calculating target value from label-id in final(output) layer
      * override properly if the layer is intended to be used as output layer
      **/
-    virtual std::pair<float_t, float_t> out_value_range() const { return {0.0, 1.0}; }  // NOLINT
+    virtual std::pair<float_t, float_t> out_value_range() const { return {float_t(0), float_t(1)}; }  // NOLINT
 
     /**
      * array of input shapes (width x height x depth)
@@ -303,7 +303,7 @@ class layer : public node {
         initialized_ = true;
     }
 
-    virtual void load(const std::vector<double>& src, int& idx) { // NOLINT
+    virtual void load(const std::vector<float_t>& src, int& idx) { // NOLINT
         auto all_weights = get_weights();
         for (auto& weight : all_weights) {
             for (auto& w : *weight) w = src[idx++];


### PR DESCRIPTION
Hi, this PR fixes problems when the calculation data type is a typedef of float.
